### PR TITLE
test: Add Cofide release and trigger index update workflows

### DIFF
--- a/.github/workflows/cofide-release.yaml
+++ b/.github/workflows/cofide-release.yaml
@@ -1,0 +1,28 @@
+# This workflow releases charts to the GitHub pages site for this repository.
+# See also trigger-index-update.yml.
+name: publish-helm-chart
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser to package and release Helm charts
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/trigger-index-update.yaml
+++ b/.github/workflows/trigger-index-update.yaml
@@ -1,0 +1,32 @@
+# This workflow is triggered by a completed GitHub pages build for this repository.
+# It sends a repository dispatch event to the helm-charts repository, which
+# causes it to aggregate the Helm index.yaml from this repository with its own.
+name: Trigger index update
+on:
+  workflow_run:
+    workflows:
+      - pages-build-deployment
+    types:
+      - completed
+
+jobs:
+  trigger:
+    name: Trigger index update
+    runs-on: ubuntu-latest
+    steps:
+      # The token requires contents:write on the remote repository in order to
+      # trigger a repository dispatch.
+      - name: Trigger index update in helm-charts repository
+        run: |
+          curl \
+            -X POST \
+            --fail \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.HELM_CHARTS_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository_owner }}/helm-charts/dispatches \
+            -d '{
+              "event_type": "charts-updated",
+              "client_payload": {
+                "repository": "${{ github.repository }}"
+              }
+            }'


### PR DESCRIPTION
This change adds two new GitHub workflows.

The Cofide release workflow releases charts to the GitHub pages site for
this repository.

The trigger index update workflow is triggered by a completed GitHub
pages build for this repository.  It sends a repository dispatch event
to the helm-charts repository, which causes it to aggregate the Helm
index.yaml from this repository with its own.
