### PR TITLE
Remove spiffe-step-ssh chart from cofide-release workflow

### DIFF
--- a/.github/workflows/cofide-ify.py
+++ b/.github/workflows/cofide-ify.py
@@ -14,7 +14,10 @@ yaml.indent(sequence=4, offset=2)
 yaml.line_width = 4096
 yaml.preserve_quotes = True
 
-CHARTS_TO_RM = ["spire-nested"]
+CHARTS_TO_RM = [
+    "spire-nested",
+    "spiffe-step-ssh",
+]
 SUBCHARTS_TO_RM = {
     "spire": [
         "spike-keeper",


### PR DESCRIPTION
The `spiffe-step-ssh` chart depends on Smallstep's step-certificates chart, but chart-releaser's package step requires the dependency repo to be registered locally. This was already fixed for `helm-release.yaml` ([#841](https://github.com/spiffe/helm-charts-hardened/pull/841)) but not for `cofide-release.yaml`, which is the workflow that actually publishes on push to main and was failing with "no repository definition for https://smallstep.github.io/helm-charts/".