### PR TITLE
Fix Chart.lock going out of sync after cofide-ify

### DIFF
--- a/.github/workflows/cofide-ify.py
+++ b/.github/workflows/cofide-ify.py
@@ -8,6 +8,7 @@
 import pathlib
 from ruamel.yaml import YAML
 import shutil
+import subprocess
 
 yaml = YAML()
 yaml.indent(sequence=4, offset=2)
@@ -68,6 +69,16 @@ def main():
 
     for chart, aliases in ALIASES_TO_RM.items():
         filter_chart_deps(chart, lambda dep: dep.get("alias") not in aliases)
+
+    # Re-sync Chart.lock with the filtered dependencies, otherwise it goes
+    # out of sync with Chart.yaml and chart-releaser refuses to package it.
+    changed_charts = set(SUBCHARTS_TO_RM) | set(ALIASES_TO_RM)
+    for chart in changed_charts:
+        print(f"Updating dependency lock for chart {chart}")
+        subprocess.run(
+            ["helm", "dependency", "update", "--skip-refresh", str(pathlib.Path("charts", chart))],
+            check=True,
+        )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/cofide-release.yaml
+++ b/.github/workflows/cofide-release.yaml
@@ -19,6 +19,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
       - name: Install ruamel.yaml
         run: |
           pip install ruamel.yaml


### PR DESCRIPTION
Regenerate the lock via `helm dependency update --skip-refresh` for each chart whose dependencies `cofide-ify.py` modifies.

---

## Background

cofide-ify.py rewrites `charts/spire/Chart.yaml` during the release workflow, stripping subcharts and aliases we don't support, but it never touched `charts/spire/Chart.lock`. `cr package` now fails with:
```
Error: the lock file (Chart.lock) is out of sync with the
dependencies file (Chart.yaml). Please update the dependencies
```
`cofide-ify.py` was written against a `charts/spire` that had no `Chart.lock` at all, so there was nothing to keep in sync and the script's rewrite of `Chart.yaml` was safe. Merging `spire-0.29.0` pulled in https://github.com/spiffe/helm-charts-hardened/pull/785, which reintroduced `Chart.lock`. `cofide-ify.py` was never updated to account for it, so the first release after that merge broke.

