### PR TITLE
Bump spire chart to 0.29.0-cofide.3

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Cofide SPIRE stack including: spire-server, spire-agent, spiffe-csi-driver, and spiffe-oidc-discovery-provider.
 
 type: application
-version: 0.29.0-cofide.2
+version: 0.29.0-cofide.3
 appVersion: "1.14.5"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/cofide/spiffe-helm-charts-hardened/tree/main/charts/spire


### PR DESCRIPTION
Missed this in https://github.com/cofide/spiffe-helm-charts-hardened/pull/37
