### PR TITLE
Require a chart version bump when a chart changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ This file is a lightweight working guide for Codex and human contributors in thi
 ## Working Agreements
 
 - Do not bump chart versions as part of normal contributions; maintainers handle release versioning
+  - Cofide: this does not apply to this fork. We publish charts from `main`, and chart-releaser
+    silently skips a chart whose version was already released, so bump the `version` in the
+    `Chart.yaml` of every chart you change. `make lint` in CI enforces this.
 - If you change `Chart.yaml` or `values.yaml`, regenerate docs with `./helm-docs.sh`
 - Prefer focused changes to a single chart or feature area per branch
 - Preserve existing Helm templating patterns and values structure unless the task requires a broader refactor

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,14 @@ help: ## Display this help.
 ##@ Linting:
 
 .PHONY: lint
+# Cofide: upstream passes --check-version-increment=false here, because upstream only
+# bumps chart versions at release time. We release from main (see
+# .github/workflows/cofide-release.yaml), and chart-releaser silently skips a chart whose
+# version has already been released, so a PR that changes a chart without bumping its
+# version would never get published. Keep the check enabled to catch that in CI.
 lint: ## Lint the charts using chart-testing
 	@echo Linting charts…
-	@ct lint --config ct.yaml --target-branch $(TARGET_BRANCH) --check-version-increment=false
+	@ct lint --config ct.yaml --target-branch $(TARGET_BRANCH) --check-version-increment=true
 
 lint-release: ## Lint the charts using chart-testing for release
 	@echo Linting charts…


### PR DESCRIPTION
Upstream disables chart-testing's version-increment check for PRs to main
because it only bumps chart versions on the release branch. We publish from
main, and chart-releaser silently skips a chart whose version was already
released, so enable the check in 'make lint' and note the divergence in
AGENTS.md.

Signed-off-by: Mark Goddard <mark@cofide.io>
